### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "common",
     "name_pretty": "Google Cloud Common",
-    "client_documentation": "https://googleapis.dev/python/common/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/common/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.