### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "common",
     "name_pretty": "Google Cloud Common",
-    "client_documentation": "https://googleapis.dev/python/common/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/common/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ This package contains generated Python types for `google.cloud.common`.
    :target: https://pypi.org/project/google-cloud-common/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-common.svg
    :target: https://pypi.org/project/google-cloud-common/
-.. _Client Library Documentation: https://googleapis.dev/python/common/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/common/latest
 
 Installation
 ------------


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.