### PR TITLE
chore: update release_level in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,6 +9,5 @@
     "repo": "googleapis/python-cloud-common",
     "distribution_name": "google-cloud-common",
     "default_version": "",
-    "codeowner_team": "",
-    "api_shortname": "common"
+    "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -3,11 +3,12 @@
     "name_pretty": "Google Cloud Common",
     "client_documentation": "https://cloud.google.com/python/docs/reference/common/latest",
     "issue_tracker": "",
-    "release_level": "ga",
+    "release_level": "stable",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/python-cloud-common",
     "distribution_name": "google-cloud-common",
     "default_version": "",
-    "codeowner_team": ""
+    "codeowner_team": "",
+    "api_shortname": "common"
 }


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 